### PR TITLE
Add sample news data on globe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# The globe of extremes
+# Sample News Globe
 
-3D Globe created by [John](https://www.esri.com/arcgis-blog/author/j_nelson/) and [Raluca](https://www.esri.com/arcgis-blog/author/raluca_zurich/) after getting inspired by [this awesome globe](https://www.fonterra.com/nz/en/campaign/from-here-to-everywhere.html#/home), [this awesome globe](https://www.instagram.com/p/Bt8zyI-gsqW/) and [this awesome globe by Vizzuality](https://www.half-earthproject.org/maps/). We used [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) to create the interactive globe and [ArcGIS Pro](https://pro.arcgis.com/) to create the basemap. We used this [Wikipedia article](https://en.wikipedia.org/wiki/Extreme_points_of_Earth) to get a list of extreme points on Earth and this [cloud image](https://visibleearth.nasa.gov/view.php?id=57747) from NASA Goddard Space Flight Center (image by Reto Stöckli) for the cloud layer.
+This project places a handful of sample news headlines on a 3D globe. It was adapted from the original "globe of extremes" demo and uses the ArcGIS API for JavaScript.
 
-I wrote about how to create the interactive globe in this [blog post](https://www.esri.com/arcgis-blog/products/js-api-arcgis/3d-gis/interactive-3d-globe/) and John wrote about the Vibrant basemap that he created for Half-Earth project in this [blog post](https://www.esri.com/arcgis-blog/products/arcgis-pro/mapping/creating-the-half-earth-vibrant-basemap/).
+The file `sample-news.geojson` contains example articles with coordinates for New York City, London, and Tokyo. No external news APIs are required.
 
-[![screenshot](./img/screenshot.png)](https://ralucanicola.github.io/the-globe-of-extremes/)
-
-[View it live](https://ralucanicola.github.io/the-globe-of-extremes/)
+To view the globe, serve the directory with any static web server and open `index.html` in your browser.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="initial-scale=1" />
-  <title>The globe of extremes</title>
+  <title>Sample News Globe</title>
 
   <link rel="stylesheet" href="https://js.arcgis.com/4.22/esri/themes/light/main.css" />
   <link rel="stylesheet" href="./style.css" />
@@ -160,13 +160,13 @@
 
       view.graphics.add(clouds);
 
-      const extremesLayer = new GeoJSONLayer({
-        url: "extreme-points.geojson",
+      const newsLayer = new GeoJSONLayer({
+        url: "sample-news.geojson",
         elevationInfo: {
           mode: "absolute-height",
           offset: offset
         },
-        copyright: "Data from <a href=\"https://en.wikipedia.org/wiki/Extreme_points_of_Earth\" target=\"_blank\">Extreme points on Earth</a> Wikipedia article | <a href=\"https://visibleearth.nasa.gov/view.php?id=57747\" target=\"_blank\">Cloud image</a> from NASA Goddard Space Flight Center (image by Reto Stöckli) for the cloud layer",
+        copyright: "Sample news data for demonstration purposes | <a href=\"https://visibleearth.nasa.gov/view.php?id=57747\" target=\"_blank\">Cloud image</a> from NASA Goddard Space Flight Center (image by Reto St\u00f6ckli) for the cloud layer",
         renderer: {
           type: "simple",
           symbol: {
@@ -189,29 +189,16 @@
         popupTemplate: {
           title: "{name}",
           content: `
-            <div class="popupImage">
-              <img src="{imageUrl}" alt="{imageCaption}"/>
-            </div>
-            <div class="popupImageCaption">{imageCaption}</div>
             <div class="popupDescription">
-              <p class="info">
-                <span class="esri-icon-favorites"></span> {type}
-              </p>
-              <p class="info">
-                <span class="esri-icon-map-pin"></span> {location}
-              </p>
-              <p class="info">
-                <span class="esri-icon-documentation"></span> {facts}
-              </p>
-            </div>
-            <div class="popupCredits">
-              Sources: <a href="{sourceUrl}" target="_blank">{source}</a> released under <a href="{sourceCopyrightUrl}">{sourceCopyright}</a>, <a href="{imageCopyrightUrl}" target="_blank">{imageCopyright}</a>.
+              <p class="info"><span class="esri-icon-documentation"></span> {newsTitle}</p>
+              <p>{newsSummary}</p>
+              <p><a href="{newsUrl}" target="_blank">Read more</a></p>
             </div>
           `
         }
       });
 
-      map.layers.add(extremesLayer);
+      map.layers.add(newsLayer);
 
       document.getElementById("close-about").addEventListener("click", closeMenu);
 
@@ -267,11 +254,9 @@
   </div>
   <div id="container">
     <div id="introDiv">
-      <h1>The globe of extremes</h1>
+      <h1>Sample News Globe</h1>
       <div id="show-intro">
-        <p> Where is the most distant point from land? What altitude does the highest permanent human settlement have?
-          Who was the first to reach the lowest point on Earth? Click on the orange icons on this globe to find out!
-        </p>
+        <p>Explore headlines from around the world. Click on the orange icons on this globe to read a sample news story for that location.</p>
         <button id="start-globe">Go to globe</button>
       </div>
       <div id="show-about" class="hidden">

--- a/sample-news.geojson
+++ b/sample-news.geojson
@@ -1,0 +1,44 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "New York City",
+        "newsTitle": "Local Parade Celebrates Cultural Diversity",
+        "newsSummary": "Thousands gather in Manhattan to celebrate the annual Cultural Parade showcasing traditions from around the world.",
+        "newsUrl": "https://example.com/new-york-news"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-74.0060, 40.7128]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "London",
+        "newsTitle": "Historic Site Reopens After Restoration",
+        "newsSummary": "The famous Tower of London has reopened to the public after months of renovations and preservation work.",
+        "newsUrl": "https://example.com/london-news"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-0.1276, 51.5074]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Tokyo",
+        "newsTitle": "Tech Expo Showcases Innovation",
+        "newsSummary": "Tech companies from across the globe gather in Tokyo to reveal their latest gadgets and innovations.",
+        "newsUrl": "https://example.com/tokyo-news"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [139.6917, 35.6895]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace extremes data with small sample news dataset
- show news headline/summary in popups
- update landing text and page title
- document new purpose in README

## Testing
- `jq . sample-news.geojson`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b89c28fd0832fb1e15bcf18a811a1